### PR TITLE
Don't split blogpost in sections

### DIFF
--- a/lib/gold_miner/blog_post.rb
+++ b/lib/gold_miner/blog_post.rb
@@ -41,17 +41,12 @@ module GoldMiner
     end
 
     def highlights
-      <<~MARKDOWN
-        ## Highlights
-
-        #{@messages.map { |message| highlight_from(message) }.join("\n")}
-      MARKDOWN
-        .chomp("")
+      @messages.map { |message| highlight_from(message) }.join("\n").chomp("")
     end
 
     def highlight_from(message)
       <<~MARKDOWN
-        ### #{message[:permalink]}
+        ## #{message[:permalink]}
 
         #{message[:text]}
       MARKDOWN

--- a/spec/gold_miner/blog_post_spec.rb
+++ b/spec/gold_miner/blog_post_spec.rb
@@ -24,17 +24,15 @@ RSpec.describe GoldMiner::BlogPost do
           author: Matheus Richard
           ---
 
-          ## Highlights
-
-          ### http://permalink-1.com
+          ## http://permalink-1.com
 
           TIL 1
 
-          ### http://permalink-2.com
+          ## http://permalink-2.com
 
           TIL 2
 
-          ### http://permalink-3.com
+          ## http://permalink-3.com
 
           Tip 1
 


### PR DESCRIPTION
This PR is a follow-up to some of the feedback on [the first issue of This Week in #dev](https://github.com/thoughtbot/robots.thoughtbot.com/pull/2231).

- Don't split blogpost in sections
  - TILs and Tips are not that different to justify different sections.
- It also sorts author names alphabetically.