### PR TITLE
Fetch Slack message author name

### DIFF
--- a/lib/gold_miner/blog_post.rb
+++ b/lib/gold_miner/blog_post.rb
@@ -78,10 +78,10 @@ module GoldMiner
 
     def authors
       @messages
-        .map { |message| "@#{message[:author_username]}" }
+        .map { |message| message[:author] }
         .uniq
         .sort
-        .then { |author_usernames| Helpers::Sentence.from(author_usernames) }
+        .then { |authors| Helpers::Sentence.from(authors) }
     end
   end
 end

--- a/lib/gold_miner/slack/client.rb
+++ b/lib/gold_miner/slack/client.rb
@@ -61,12 +61,16 @@ module GoldMiner
       warn_on_multiple_pages(result)
 
       result.messages.matches.map do |match|
-        {
+        Slack::Message.new(
           text: match.text,
-          author_username: match.username,
+          author: fetch_author_name(match.user),
           permalink: match.permalink
-        }
+        )
       end
+    end
+
+    def fetch_author_name(user_id)
+      @slack.users_info(user: user_id).user.profile.real_name
     end
 
     # For simplicity, I'm not handling API pagination yet

--- a/lib/gold_miner/slack/message.rb
+++ b/lib/gold_miner/slack/message.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module GoldMiner
+  class Slack::Message
+    def initialize(text:, author:, permalink:)
+      @text = text
+      @author = author
+      @permalink = permalink
+    end
+
+    def [](attribute)
+      instance_variable_get("@#{attribute}")
+    end
+
+    def ==(other)
+      self[:text] == other[:text] &&
+        self[:author] == other[:author] &&
+        self[:permalink] == other[:permalink]
+    end
+  end
+end

--- a/spec/gold_miner/blog_post_spec.rb
+++ b/spec/gold_miner/blog_post_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe GoldMiner::BlogPost do
     it "creates a blogpost from a list of messages" do
       travel_to "2022-10-07" do
         messages = [
-          {text: "TIL 1", author_username: "user2", permalink: "http://permalink-1.com"},
-          {text: "TIL 2", author_username: "user1", permalink: "http://permalink-2.com"},
-          {text: "Tip 1", author_username: "user2", permalink: "http://permalink-3.com"}
+          GoldMiner::Slack::Message.new(text: "TIL 1", author: "John Doe", permalink: "http://permalink-1.com"),
+          GoldMiner::Slack::Message.new(text: "TIL 2", author: "Jane Smith", permalink: "http://permalink-2.com"),
+          GoldMiner::Slack::Message.new(text: "Tip 1", author: "John Doe", permalink: "http://permalink-3.com")
         ]
         blogpost = GoldMiner::BlogPost.new(slack_channel: "design", messages: messages, since: "2022-09-30")
 
@@ -42,7 +42,7 @@ RSpec.describe GoldMiner::BlogPost do
 
           ## Thanks
 
-          This edition was brought to you by: @user1 and @user2. Thanks to all contributors! 🎉
+          This edition was brought to you by: Jane Smith and John Doe. Thanks to all contributors! 🎉
         MARKDOWN
       end
     end

--- a/spec/gold_miner/slack/message_spec.rb
+++ b/spec/gold_miner/slack/message_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "ostruct"
+
+RSpec.describe GoldMiner::Slack::Message do
+  describe "#[]" do
+    it "returns the message attribute" do
+      message = described_class.new(
+        text: "TIL",
+        author: "@JohnDoe",
+        permalink: "https:///message-1-permalink.com"
+      )
+
+      expect(message[:text]).to eq "TIL"
+      expect(message[:author]).to eq "@JohnDoe"
+      expect(message[:permalink]).to eq "https:///message-1-permalink.com"
+    end
+  end
+
+  describe "#==" do
+    it "returns true if the messages have the same attributes" do
+      message1 = described_class.new(
+        text: "TIL",
+        author: "@JohnDoe",
+        permalink: "https:///message-1-permalink.com"
+      )
+      message2 = described_class.new(
+        text: "TIL",
+        author: "@JohnDoe",
+        permalink: "https:///message-1-permalink.com"
+      )
+
+      result = message1 == message2
+
+      expect(result).to be true
+    end
+
+    it "returns false if any of the attributes are different" do
+      message1 = described_class.new(
+        text: "TIL",
+        author: "@JohnDoe",
+        permalink: "https:///message-1-permalink.com"
+      )
+      message2 = described_class.new(
+        text: "TIL2",
+        author: "@JohnDoe",
+        permalink: "https:///message-1-permalink.com"
+      )
+      message3 = described_class.new(
+        text: "TIL",
+        author: "@JohnDoe2",
+        permalink: "https:///message-1-permalink.com"
+      )
+      message4 = described_class.new(
+        text: "TIL",
+        author: "@JohnDoe",
+        permalink: "https:///message-2-permalink.com"
+      )
+
+      expect(message1 == message2).to be false
+      expect(message1 == message3).to be false
+      expect(message1 == message4).to be false
+      expect(message2 == message3).to be false
+      expect(message2 == message4).to be false
+      expect(message3 == message4).to be false
+    end
+  end
+end


### PR DESCRIPTION
This removes some manual work. Before, it was up to the blog post author to get the message author names based on their Slack usernames.

Unfortunately, it requires another request to the Slack API (names aren't available on the message search response), which creates an N+1 problem. While it's bad for performance, we probably won't have more than 10 messages, so it's not that many extra requests.

I also introduced the Slack::Message class. It doesn't have any particular behavior, but I already have plans for extra features. It implements #[], so we can use instances like hashes. This makes it easier to swap hashes for this class without much refactoring. For instance, I didn't touch any blog post writer class with this change.

Fixes #6