### PR TITLE
Send messages using the third person to OpenAI

### DIFF
--- a/lib/gold_miner/blog_post/open_ai_writer.rb
+++ b/lib/gold_miner/blog_post/open_ai_writer.rb
@@ -28,7 +28,7 @@ module GoldMiner
       end
 
       def summarize(message)
-        summary = ask_openai("Summarize this text: #{message[:text]}")
+        summary = ask_openai("Summarize this text:\n\n#{message.as_conversation}")
 
         if summary
           "#{summary}\n\nSource: #{message[:permalink]}"

--- a/lib/gold_miner/slack/message.rb
+++ b/lib/gold_miner/slack/message.rb
@@ -17,5 +17,9 @@ module GoldMiner
         self[:author] == other[:author] &&
         self[:permalink] == other[:permalink]
     end
+
+    def as_conversation
+      "#{self[:author]} says: #{self[:text]}"
+    end
   end
 end

--- a/spec/gold_miner/slack/message_spec.rb
+++ b/spec/gold_miner/slack/message_spec.rb
@@ -66,4 +66,18 @@ RSpec.describe GoldMiner::Slack::Message do
       expect(message3 == message4).to be false
     end
   end
+
+  describe "#as_conversation" do
+    it "returns the message content with the author name" do
+      message = described_class.new(
+        text: "TIL",
+        author: "@JohnDoe",
+        permalink: "https:///message-1-permalink.com"
+      )
+
+      conversation = message.as_conversation
+
+      expect(conversation).to eq "@JohnDoe says: TIL"
+    end
+  end
 end


### PR DESCRIPTION
This small change makes OpenAI create better summaries. The original messages might be in the first person, so their summaries may be generated in the first person.

The method `SlackMessage#as_conversation` will also be helpful when we create summaries for a whole thread of messages.