### PR TITLE
Create blog posts parts asynchronously

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     gold_miner (0.1.0)
+      async
       dotenv (~> 2.8.0)
       dry-monads (~> 1.3.0)
       ruby-openai (~> 3.0.0)
@@ -14,7 +15,13 @@ GEM
     addressable (2.8.1)
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
+    async (2.3.1)
+      console (~> 1.10)
+      io-event (~> 1.1)
+      timers (~> 4.1)
     concurrent-ruby (1.1.10)
+    console (1.16.2)
+      fiber-local
     crack (0.4.5)
       rexml
     diff-lcs (1.5.0)
@@ -37,12 +44,14 @@ GEM
     faraday-multipart (1.0.4)
       multipart-post (~> 2)
     faraday-net_http (3.0.2)
+    fiber-local (1.0.0)
     gli (2.21.0)
     hashdiff (1.0.1)
     hashie (5.0.0)
     httparty (0.20.0)
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
+    io-event (1.1.4)
     json (2.6.3)
     language_server-protocol (3.17.0.2)
     mime-types (3.4.1)
@@ -108,6 +117,7 @@ GEM
       rubocop (= 1.42.0)
       rubocop-performance (= 1.15.2)
     timecop (0.9.6)
+    timers (4.3.5)
     unicode-display_width (2.4.2)
     webmock (3.18.1)
       addressable (>= 2.8.0)

--- a/gold_miner.gemspec
+++ b/gold_miner.gemspec
@@ -31,7 +31,6 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  # Uncomment to register a new dependency of your gem
   spec.add_dependency "async"
   spec.add_dependency "dotenv", "~> 2.8.0"
   spec.add_dependency "dry-monads", "~> 1.3.0"

--- a/gold_miner.gemspec
+++ b/gold_miner.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   # Uncomment to register a new dependency of your gem
+  spec.add_dependency "async"
   spec.add_dependency "dotenv", "~> 2.8.0"
   spec.add_dependency "dry-monads", "~> 1.3.0"
   spec.add_dependency "ruby-openai", "~> 3.0.0"

--- a/spec/gold_miner/blog_post_spec.rb
+++ b/spec/gold_miner/blog_post_spec.rb
@@ -46,5 +46,73 @@ RSpec.describe GoldMiner::BlogPost do
         MARKDOWN
       end
     end
+
+    it "creates a blog post asynchronously" do
+      sleep_writer = Class.new do
+        def initialize(seconds_of_sleep:)
+          @seconds_of_sleep = seconds_of_sleep
+        end
+
+        def extract_topics_from(message)
+          sleep @seconds_of_sleep
+
+          ["test", "test2"]
+        end
+
+        def give_title_to(message)
+          sleep @seconds_of_sleep
+
+          "test"
+        end
+
+        def summarize(message)
+          sleep @seconds_of_sleep
+
+          "test"
+        end
+      end
+      messages = [
+        GoldMiner::Slack::Message.new(text: "TIL 1", author: "John Doe", permalink: "http://permalink-1.com"),
+        GoldMiner::Slack::Message.new(text: "TIL 2", author: "Jane Smith", permalink: "http://permalink-2.com")
+      ]
+      seconds_of_sleep = 1
+      blogpost = GoldMiner::BlogPost.new(
+        slack_channel: "design",
+        messages: messages,
+        since: "2022-09-30",
+        writer: sleep_writer.new(seconds_of_sleep: seconds_of_sleep)
+      )
+
+      t0 = Time.now
+      result = blogpost.to_s
+      elapsed_time = Time.now - t0
+
+      expect(elapsed_time).to be_between(seconds_of_sleep, seconds_of_sleep + 1)
+      expect(result).to eq <<~MARKDOWN
+        ---
+        title: "This week in #design (Sep 30, 2022)"
+        tags: this-week-in-design, test, test2
+        teaser: >
+          Highlights of what happened in our #design channel on Slack this week.
+        author: Matheus Richard
+        ---
+
+        Welcome to another edition of This Week in #dev, a series of posts where we
+        bring some of the most interesting Slack conversations to the public.
+        Today we're talking about: test and test2.
+
+        ## test
+
+        test
+
+        ## test
+
+        test
+
+        ## Thanks
+
+        This edition was brought to you by: Jane Smith and John Doe. Thanks to all contributors! 🎉
+      MARKDOWN
+    end
   end
 end


### PR DESCRIPTION
This leverages [Ruby's FiberScheduler] and the [gem `async`] to generate parts of a blog post asynchronously. This mainly benefits the OpenAI writer, which makes HTTP requests.

Now, all the requests happen in parallel. This means that instead of taking the sum of the duration of all requests, creating a blog post will take the time of the slowest request only (plus a small internal overhead).

Another benefit is that this is implemented in the BlogPost class itself, so every writer instance can benefit from this speed-up.

[Ruby's FiberScheduler]: https://docs.ruby-lang.org/en/3.0/Fiber/SchedulerInterface.html
[gem `async`]: https://github.com/socketry/async

---

It's hard to say how much this speeds up, since the response times for OpenAI vary a lot, but IME is cutting the total time to generate the blog post in 2 times (from ~30s to ~10-12s).