### PR TITLE
Add section "Register your own app with Slack"

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ available for User Tokens.
 - Then scroll back up to "OAuth Tokens for Your Workspace"
   and click "Install to Workspace"
 - You will be redirected to a page asking you to allow your app to be
-  installed to the workspace and listing the scopes/permissons you've selected
+  installed to the workspace and listing the scopes/permissions you've selected
 - Click "Allow"
 
 [search.messages]: https://api.slack.com/methods/search.messages

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ⛏ GoldMiner
 
 GoldMiner is a tool for finding interesting\* messages in a Slack channel and
-turning that into a blog post for the [thoughtbot blog].
+turning them into a blog post for the [thoughtbot blog].
 
 It uses the Slack API to [search for messages in a channel], then it groups and
 [formats them into a markdown blog post].
@@ -10,7 +10,7 @@ _\* At this point, "interesting" means "messages that contain 'TIL', 'tip' or
 have been reacted with the :rupee-gold: emoji"._
 
 [thoughtbot blog]: https://thoughtbot.com/blog
-[search for messages in a channel]: https://github.com/thoughtbot/gold_miner/blob/main/lib/gold_miner/slack_client.rb#L30
+[search for messages in a channel]: https://github.com/thoughtbot/gold_miner/blob/main/lib/gold_miner/slack/client.rb#L34
 [formats them into a markdown blog post]: https://github.com/thoughtbot/gold_miner/blob/main/lib/gold_miner/blog_post.rb#L14
 
 ## Installation
@@ -33,7 +33,10 @@ API Token"). If that doesn't work, ask [someone on the team] for help.
 [on 1password]: https://start.1password.com/signin
 [someone on the team]: https://thoughtbot.slack.com/apps/A040W2T48BF-gold-miner?tab=more_info
 
-After setting the token on the .env file, rerun the setup script to finish the
+Alternatively, see the "Register your own app with Slack" section below for the
+steps to create your own app and User Token.
+
+After setting the token on the `.env` file, rerun the setup script to finish the
 installation.
 
 ### Setup OpenAI (optional)
@@ -77,3 +80,35 @@ prompt that will allow you to experiment.
 
 Bug reports and pull requests are welcome on GitHub at
 https://github.com/thoughtbot/gold_miner.
+
+## Register your own app with Slack
+
+To register an app with Slack you just need to give it a name and select a
+workspace to develop it. After that, you will be able to generate Bot and User
+Tokens from your App settings page. A User Token is needed instead of a
+Bot Token because Gold Miner uses Slack's [search.messages] API which is only
+available for User Tokens.
+
+- Go to https://api.slack.com/apps and click on "Create New App"
+  and then click "From scratch"
+- Give it a name, select your workspace, and click "Create App"
+- After that, go to "Add features and functionality > Permissions"
+- Scroll down to "Scopes > User Token Scopes" and give your app the
+  following scopes:
+  - `search:read` to have access to [search.messages]
+  - `users:read` to have access to [users.info]
+- Then scroll back up to "OAuth Tokens for Your Workspace"
+  and click "Install to Workspace"
+- You will be redirected to a page asking you to allow your app to be
+  installed to the workspace and listing the scopes/permissons you've selected
+- Click "Allow"
+
+[search.messages]: https://api.slack.com/methods/search.messages
+[users.info]: https://api.slack.com/methods/users.info
+
+Now you have your personal app installed to the workspace and with Bot and User
+Tokens generated.
+
+Go back to you App settings page, click "Add features and functionality >
+Permissions", then copy the "User OAuth Token" and set it to `SLACK_API_TOKEN`
+in your `.env` file.


### PR DESCRIPTION
I wanted to set up Gold Miner without using the shared token from 1Password.

I went through the steps to register an app with Slack and generate a User Token
with the scopes we need, and documented that in README.md.