### PR TITLE
Introduce gold nuggets

### DIFF
--- a/lib/gold_miner.rb
+++ b/lib/gold_miner.rb
@@ -16,10 +16,10 @@ module GoldMiner
       .fmap { |client| explore(slack_channel, client) }
   end
 
-  def convert_messages_to_blogpost(channel, messages, blog_post_builder: GoldMiner::BlogPost)
+  def convert_messages_to_blogpost(channel, gold_nuggets, blog_post_builder: GoldMiner::BlogPost)
     blog_post_builder.new(
       slack_channel: channel,
-      messages: messages,
+      messages: gold_nuggets,
       since: Helpers::Time.last_friday,
       writer: BlogPost::Writer.from_env
     )

--- a/lib/gold_miner.rb
+++ b/lib/gold_miner.rb
@@ -19,7 +19,7 @@ module GoldMiner
   def convert_messages_to_blogpost(channel, gold_nuggets, blog_post_builder: GoldMiner::BlogPost)
     blog_post_builder.new(
       slack_channel: channel,
-      messages: gold_nuggets,
+      gold_nuggets: gold_nuggets,
       since: Helpers::Time.last_friday,
       writer: BlogPost::Writer.from_env
     )

--- a/lib/gold_miner/author.rb
+++ b/lib/gold_miner/author.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module GoldMiner
+  Author = Data.define(:id, :name, :link) do
+    alias_method :to_s, :name
+
+    def name_with_link_reference
+      "[#{name}][#{id}]"
+    end
+
+    def reference_link
+      "[#{id}]: #{link}"
+    end
+  end
+end

--- a/lib/gold_miner/blog_post.rb
+++ b/lib/gold_miner/blog_post.rb
@@ -4,9 +4,9 @@ require "async"
 
 module GoldMiner
   class BlogPost
-    def initialize(slack_channel:, messages:, since:, writer: SimpleWriter.new)
+    def initialize(slack_channel:, gold_nuggets:, since:, writer: SimpleWriter.new)
       @slack_channel = slack_channel
-      @messages = messages
+      @gold_nuggets = gold_nuggets
       @since = since
       @writer = writer
     end
@@ -51,16 +51,16 @@ module GoldMiner
     end
 
     def highlights
-      @messages
-        .map { |message| Async { highlight_from(message) } }
+      @gold_nuggets
+        .map { |gold_nugget| Async { highlight_from(gold_nugget) } }
         .map(&:wait)
         .join("\n")
         .chomp("")
     end
 
-    def highlight_from(message)
-      title_task = Async { @writer.give_title_to(message) }
-      summary_task = Async { @writer.summarize(message) }
+    def highlight_from(gold_nugget)
+      title_task = Async { @writer.give_title_to(gold_nugget) }
+      summary_task = Async { @writer.summarize(gold_nugget) }
 
       <<~MARKDOWN
         ## #{title_task.wait}
@@ -80,19 +80,19 @@ module GoldMiner
     end
 
     def topics
-      @topics ||= @messages
-        .map { |message| Async { topics_from(message) } }
+      @topics ||= @gold_nuggets
+        .map { |gold_nugget| Async { topics_from(gold_nugget) } }
         .flat_map(&:wait)
         .uniq
     end
 
-    def topics_from(message)
-      @writer.extract_topics_from(message)
+    def topics_from(gold_nugget)
+      @writer.extract_topics_from(gold_nugget)
     end
 
     def authors
-      @messages
-        .map { |message| message.author.name_with_link_reference }
+      @gold_nuggets
+        .map { |gold_nugget| gold_nugget.author.name_with_link_reference }
         .uniq
         .sort
         .then { |authors| Helpers::Sentence.from(authors) }

--- a/lib/gold_miner/blog_post/open_ai_writer.rb
+++ b/lib/gold_miner/blog_post/open_ai_writer.rb
@@ -10,35 +10,35 @@ module GoldMiner
         @fallback_writer = fallback_writer
       end
 
-      def extract_topics_from(message)
-        topics_json = ask_openai("Extract the 3 most relevant topics, if possible in one word, from this text as a single parseable JSON array: #{message[:text]}")
+      def extract_topics_from(gold_nugget)
+        topics_json = ask_openai("Extract the 3 most relevant topics, if possible in one word, from this text as a single parseable JSON array: #{gold_nugget.content}")
 
         if (topics = try_parse_json(topics_json))
           topics
         else
-          fallback_topics_for(message)
+          fallback_topics_for(gold_nugget)
         end
       end
 
-      def give_title_to(message)
-        title = ask_openai("Give a small title to this text: #{message[:text]}")
+      def give_title_to(gold_nugget)
+        title = ask_openai("Give a small title to this text: #{gold_nugget.content}")
         title = title&.delete_prefix('"')&.delete_suffix('"')
 
-        title || fallback_title_for(message)
+        title || fallback_title_for(gold_nugget)
       end
 
-      def summarize(message)
+      def summarize(gold_nugget)
         summary = ask_openai <<~PROMPT
           Summarize the following markdown message without removing the author's blog link. Return the summary as markdown.
 
           Message:
-          #{message.as_conversation}
+          #{gold_nugget.as_conversation}
         PROMPT
 
         if summary
-          "#{summary}\n\nSource: #{message[:permalink]}"
+          "#{summary}\n\nSource: #{gold_nugget.source}"
         else
-          fallback_summary_for(message)
+          fallback_summary_for(gold_nugget)
         end
       end
 
@@ -63,16 +63,16 @@ module GoldMiner
         nil
       end
 
-      def fallback_title_for(message)
-        @fallback_writer.give_title_to(message)
+      def fallback_title_for(gold_nugget)
+        @fallback_writer.give_title_to(gold_nugget)
       end
 
-      def fallback_summary_for(message)
-        @fallback_writer.summarize(message)
+      def fallback_summary_for(gold_nugget)
+        @fallback_writer.summarize(gold_nugget)
       end
 
-      def fallback_topics_for(message)
-        @fallback_writer.extract_topics_from(message)
+      def fallback_topics_for(gold_nugget)
+        @fallback_writer.extract_topics_from(gold_nugget)
       end
 
       def try_parse_json(json)

--- a/lib/gold_miner/blog_post/simple_writer.rb
+++ b/lib/gold_miner/blog_post/simple_writer.rb
@@ -7,16 +7,16 @@ module GoldMiner
         @topic_extractor = topic_extractor
       end
 
-      def extract_topics_from(message)
-        @topic_extractor.call(message[:text])
+      def extract_topics_from(gold_nugget)
+        @topic_extractor.call(gold_nugget.content)
       end
 
-      def give_title_to(message)
-        message[:permalink]
+      def give_title_to(gold_nugget)
+        gold_nugget.source
       end
 
-      def summarize(message)
-        message[:text]
+      def summarize(gold_nugget)
+        gold_nugget.content
       end
     end
   end

--- a/lib/gold_miner/gold_nugget.rb
+++ b/lib/gold_miner/gold_nugget.rb
@@ -1,5 +1,13 @@
 # frozen_string_literal: true
 
 module GoldMiner
-  GoldNugget = Data.define(:content, :author, :source)
+  GoldNugget = Data.define(:content, :author, :source) do
+    def as_conversation
+      <<~MARKDOWN
+        #{author.name_with_link_reference} says: #{content}
+
+        #{author.reference_link}
+      MARKDOWN
+    end
+  end
 end

--- a/lib/gold_miner/gold_nugget.rb
+++ b/lib/gold_miner/gold_nugget.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module GoldMiner
+  GoldNugget = Data.define(:content, :author, :source)
+end

--- a/lib/gold_miner/slack/client.rb
+++ b/lib/gold_miner/slack/client.rb
@@ -71,7 +71,6 @@ module GoldMiner
           .user
           .profile
           .real_name
-      # .tap { |name| @user_name_cache[user_id] = name }
     end
 
     def user_info(user_id)

--- a/lib/gold_miner/slack/client.rb
+++ b/lib/gold_miner/slack/client.rb
@@ -33,9 +33,23 @@ module GoldMiner
     def search_messages(query)
       @slack
         .search_messages(query:)
-        .tap { |response|
+        .then { |response|
           warn_on_multiple_pages(response)
           fetch_author_names(response)
+
+          response.messages.matches
+        }
+        .map { |message|
+          Slack::Message.new(
+            id: message.id,
+            text: message.text,
+            user: Slack::User.new(
+              id: message.user,
+              name: message.author_real_name,
+              username: message.username
+            ),
+            permalink: message.permalink
+          )
         }
     end
 

--- a/lib/gold_miner/slack/client.rb
+++ b/lib/gold_miner/slack/client.rb
@@ -37,19 +37,18 @@ module GoldMiner
           warn_on_multiple_pages(response)
           fetch_author_names(response)
 
-          response.messages.matches
-        }
-        .map { |message|
-          Slack::Message.new(
-            id: message.id,
-            text: message.text,
-            user: Slack::User.new(
-              id: message.user,
-              name: message.author_real_name,
-              username: message.username
-            ),
-            permalink: message.permalink
-          )
+          response.messages.matches.map { |message|
+            Slack::Message.new(
+              id: message.id,
+              text: message.text,
+              user: Slack::User.new(
+                id: message.user,
+                name: message.author_real_name,
+                username: message.username
+              ),
+              permalink: message.permalink
+            )
+          }
         }
     end
 

--- a/lib/gold_miner/slack/message.rb
+++ b/lib/gold_miner/slack/message.rb
@@ -2,16 +2,8 @@
 
 module GoldMiner
   module Slack
-    Message = Data.define(:text, :author, :permalink) do
+    Message = Data.define(:id, :text, :user, :permalink) do
       alias_method :[], :public_send
-
-      def as_conversation
-        <<~MARKDOWN
-          #{author.name_with_link_reference} says: #{text}
-
-          #{author.reference_link}
-        MARKDOWN
-      end
     end
   end
 end

--- a/lib/gold_miner/slack/user.rb
+++ b/lib/gold_miner/slack/user.rb
@@ -2,16 +2,6 @@
 
 module GoldMiner
   module Slack
-    User = Data.define(:id, :name, :username, :link) do
-      alias_method :to_s, :name
-
-      def name_with_link_reference
-        "[#{name}][#{username}]"
-      end
-
-      def reference_link
-        "[#{username}]: #{link}"
-      end
-    end
+    User = Data.define(:id, :name, :username)
   end
 end

--- a/lib/gold_miner/slack_explorer.rb
+++ b/lib/gold_miner/slack_explorer.rb
@@ -30,23 +30,22 @@ module GoldMiner
 
     def merge_messages(*search_tasks)
       search_tasks
-        .flat_map { |task| task.wait.messages.matches }
+        .flat_map(&:wait)
         .uniq { |message| message[:permalink] }
         .map { |message|
-          Slack::Message.new(
-            text: message.text,
+          GoldNugget.new(
+            content: message.text,
             author: author_of(message),
-            permalink: message.permalink
+            source: message.permalink
           )
         }
     end
 
     def author_of(message)
-      Slack::User.new(
-        name: message.author_real_name,
-        link: link_for(message.username),
-        id: message.user,
-        username: message.username
+      Author.new(
+        id: message.user.username,
+        name: message.user.name,
+        link: link_for(message.user.username)
       )
     end
 

--- a/spec/gold_miner/blog_post/simple_writer_spec.rb
+++ b/spec/gold_miner/blog_post/simple_writer_spec.rb
@@ -11,20 +11,20 @@ RSpec.describe GoldMiner::BlogPost::SimpleWriter do
     it "delegates to the topic extractor" do
       topics = ["topic-#{rand}"]
       topic_extractor = double(:topic_extractor, call: topics)
-      message = {text: "message text"}
+      gold_nugget = TestFactories.create_gold_nugget(content: "message text")
 
       writer = described_class.new(topic_extractor: topic_extractor)
-      extracted_topics = writer.extract_topics_from(message)
+      extracted_topics = writer.extract_topics_from(gold_nugget)
 
       expect(extracted_topics).to eq(topics)
-      expect(topic_extractor).to have_received(:call).with(message[:text])
+      expect(topic_extractor).to have_received(:call).with(gold_nugget.content)
     end
 
     it "has a default topic extractor" do
-      message = {text: "message text"}
+      gold_nugget = TestFactories.create_gold_nugget(content: "message text")
       writer = described_class.new
 
-      extracted_topics = writer.extract_topics_from(message)
+      extracted_topics = writer.extract_topics_from(gold_nugget)
 
       expect(extracted_topics).to be_a Array
     end
@@ -32,10 +32,10 @@ RSpec.describe GoldMiner::BlogPost::SimpleWriter do
 
   describe "#give_title_to" do
     it "returns the message permalink" do
-      message = {permalink: "https://permalink.com", text: "message text"}
+      gold_nugget = TestFactories.create_gold_nugget(source: "https://permalink.com", content: "message text")
       writer = described_class.new
 
-      title = writer.give_title_to(message)
+      title = writer.give_title_to(gold_nugget)
 
       expect(title).to eq("https://permalink.com")
     end
@@ -43,12 +43,12 @@ RSpec.describe GoldMiner::BlogPost::SimpleWriter do
 
   describe "#summarize" do
     it "returns the given text" do
-      message = {text: "message text"}
+      gold_nugget = TestFactories.create_gold_nugget(content: "message text")
       writer = described_class.new
 
-      summary = writer.summarize(message)
+      summary = writer.summarize(gold_nugget)
 
-      expect(summary).to eq(message[:text])
+      expect(summary).to eq(gold_nugget.content)
     end
   end
 end

--- a/spec/gold_miner/blog_post_spec.rb
+++ b/spec/gold_miner/blog_post_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe GoldMiner::BlogPost do
           TestFactories.create_gold_nugget(content: "TIL 2", author: author2, source: "http://permalink-2.com"),
           TestFactories.create_gold_nugget(content: "Tip 1", author: author1, source: "http://permalink-3.com")
         ]
-        blogpost = GoldMiner::BlogPost.new(slack_channel: "design", messages: gold_nuggets, since: "2022-09-30")
+        blogpost = GoldMiner::BlogPost.new(slack_channel: "design", gold_nuggets: gold_nuggets, since: "2022-09-30")
 
         result = blogpost.to_s
 
@@ -83,7 +83,7 @@ RSpec.describe GoldMiner::BlogPost do
       seconds_of_sleep = 0.5
       blogpost = GoldMiner::BlogPost.new(
         slack_channel: "design",
-        messages: gold_nuggets,
+        gold_nuggets: gold_nuggets,
         since: "2022-09-30",
         writer: sleep_writer.new(seconds_of_sleep: seconds_of_sleep)
       )

--- a/spec/gold_miner/blog_post_spec.rb
+++ b/spec/gold_miner/blog_post_spec.rb
@@ -4,16 +4,16 @@ require "spec_helper"
 
 RSpec.describe GoldMiner::BlogPost do
   describe "#to_s" do
-    it "creates a blogpost from a list of messages" do
+    it "creates a blogpost from a list of gold nuggets" do
       travel_to "2022-10-07" do
-        author1 = TestFactories.create_slack_user(id: "U123", name: "John Doe", username: "john.doe", link: "https://example.com/john.doe")
-        author2 = TestFactories.create_slack_user(id: "U456", name: "Jane Smith", username: "jane.smith", link: "https://example.com/jane.smith")
-        messages = [
-          GoldMiner::Slack::Message.new(text: "TIL 1", author: author1, permalink: "http://permalink-1.com"),
-          GoldMiner::Slack::Message.new(text: "TIL 2", author: author2, permalink: "http://permalink-2.com"),
-          GoldMiner::Slack::Message.new(text: "Tip 1", author: author1, permalink: "http://permalink-3.com")
+        author1 = TestFactories.create_author(name: "John Doe", id: "john.doe", link: "https://example.com/john.doe")
+        author2 = TestFactories.create_author(name: "Jane Smith", id: "jane.smith", link: "https://example.com/jane.smith")
+        gold_nuggets = [
+          TestFactories.create_gold_nugget(content: "TIL 1", author: author1, source: "http://permalink-1.com"),
+          TestFactories.create_gold_nugget(content: "TIL 2", author: author2, source: "http://permalink-2.com"),
+          TestFactories.create_gold_nugget(content: "Tip 1", author: author1, source: "http://permalink-3.com")
         ]
-        blogpost = GoldMiner::BlogPost.new(slack_channel: "design", messages: messages, since: "2022-09-30")
+        blogpost = GoldMiner::BlogPost.new(slack_channel: "design", messages: gold_nuggets, since: "2022-09-30")
 
         result = blogpost.to_s
 
@@ -74,16 +74,16 @@ RSpec.describe GoldMiner::BlogPost do
           "test"
         end
       end
-      author1 = TestFactories.create_slack_user(id: "U123", name: "John Doe", username: "john.doe", link: "https://example.com/john.doe")
-      author2 = TestFactories.create_slack_user(id: "U456", name: "Jane Smith", username: "jane.smith", link: "https://example.com/jane.smith")
-      messages = [
-        GoldMiner::Slack::Message.new(text: "TIL 1", author: author1, permalink: "http://permalink-1.com"),
-        GoldMiner::Slack::Message.new(text: "TIL 2", author: author2, permalink: "http://permalink-2.com")
+      author1 = TestFactories.create_author(name: "John Doe", id: "john.doe", link: "https://example.com/john.doe")
+      author2 = TestFactories.create_author(name: "Jane Smith", id: "jane.smith", link: "https://example.com/jane.smith")
+      gold_nuggets = [
+        TestFactories.create_gold_nugget(content: "TIL 1", author: author1, source: "http://permalink-1.com"),
+        TestFactories.create_gold_nugget(content: "TIL 2", author: author2, source: "http://permalink-2.com")
       ]
       seconds_of_sleep = 0.5
       blogpost = GoldMiner::BlogPost.new(
         slack_channel: "design",
-        messages: messages,
+        messages: gold_nuggets,
         since: "2022-09-30",
         writer: sleep_writer.new(seconds_of_sleep: seconds_of_sleep)
       )

--- a/spec/gold_miner/gold_nugget_spec.rb
+++ b/spec/gold_miner/gold_nugget_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe GoldMiner::GoldNugget do
+  describe "#as_conversation" do
+    it "returns the gold nugget content with the author name and link" do
+      author = TestFactories.create_author(name: "Matz", id: "the-ruby-matz", link: "https://example.com/matz")
+      gold_nugget = described_class.new(
+        content: "TIL",
+        author: author,
+        source: "https:///message-1-permalink.com"
+      )
+
+      conversation = gold_nugget.as_conversation
+
+      expect(conversation).to eq <<~MARKDOWN
+        [Matz][the-ruby-matz] says: TIL
+
+        [the-ruby-matz]: https://example.com/matz
+      MARKDOWN
+    end
+  end
+end

--- a/spec/gold_miner/slack/client_spec.rb
+++ b/spec/gold_miner/slack/client_spec.rb
@@ -76,11 +76,11 @@ RSpec.describe GoldMiner::Slack::Client do
       )
       slack = described_class.build(api_token: token).value!
 
-      messages = slack.search_messages(search_query).messages.matches
+      messages = slack.search_messages(search_query)
 
       expect(messages).to match_array [
-        msg1.merge("author_real_name" => user1.name),
-        msg2.merge("author_real_name" => user2.name)
+        TestFactories.create_slack_message(id: msg1["id"], text: msg1["text"], user: user1, permalink: msg1["permalink"]),
+        TestFactories.create_slack_message(id: msg2["id"], text: msg2["text"], user: user2, permalink: msg2["permalink"])
       ]
     end
 
@@ -108,7 +108,7 @@ RSpec.describe GoldMiner::Slack::Client do
       )
       slack = described_class.build(api_token: token).value!
 
-      slack.search_messages(search_query).messages.matches
+      slack.search_messages(search_query)
 
       expect(WebMock).to have_requested(:post, "https://slack.com/api/users.info").once
     end

--- a/spec/gold_miner/slack/message_spec.rb
+++ b/spec/gold_miner/slack/message_spec.rb
@@ -5,35 +5,17 @@ require "spec_helper"
 RSpec.describe GoldMiner::Slack::Message do
   describe "#[]" do
     it "returns the message attribute" do
-      author = TestFactories.create_slack_user
+      user = TestFactories.create_slack_user
       message = described_class.new(
+        id: "message-1",
         text: "TIL",
-        author: author,
+        user: user,
         permalink: "https:///message-1-permalink.com"
       )
 
       expect(message[:text]).to eq "TIL"
-      expect(message[:author]).to eq author
+      expect(message[:user]).to eq user
       expect(message[:permalink]).to eq "https:///message-1-permalink.com"
-    end
-  end
-
-  describe "#as_conversation" do
-    it "returns the message content with the author name and link" do
-      author = TestFactories.create_slack_user(name: "Matz", username: "the-ruby-matz", link: "https://example.com/matz")
-      message = described_class.new(
-        text: "TIL",
-        author: author,
-        permalink: "https:///message-1-permalink.com"
-      )
-
-      conversation = message.as_conversation
-
-      expect(conversation).to eq <<~MARKDOWN
-        [Matz][the-ruby-matz] says: TIL
-
-        [the-ruby-matz]: https://example.com/matz
-      MARKDOWN
     end
   end
 end

--- a/spec/support/test_factories.rb
+++ b/spec/support/test_factories.rb
@@ -5,16 +5,16 @@ module TestFactories
     default_attributes = {
       id: "U123",
       name: "John Doe",
-      username: "john.doe",
-      link: "https://example.com/slack/authors/john.doe"
+      username: "john.doe"
     }
     GoldMiner::Slack::User.new(**default_attributes.merge(overriden_attributes))
   end
 
   def create_slack_message(overriden_attributes = {})
     default_attributes = {
+      id: "msg-id",
       text: "Hello world",
-      author: create_slack_user,
+      user: create_slack_user,
       permalink: "https://example.com/slack/messages/123"
     }
     GoldMiner::Slack::Message.new(**default_attributes.merge(overriden_attributes))

--- a/spec/support/test_factories.rb
+++ b/spec/support/test_factories.rb
@@ -1,6 +1,24 @@
 module TestFactories
   extend self
 
+  def create_author(overriden_attributes = {})
+    default_attributes = {
+      id: "author-id",
+      name: "John Doe",
+      link: "https://example.com/users/john.doe"
+    }
+    GoldMiner::Author.new(**default_attributes.merge(overriden_attributes))
+  end
+
+  def create_gold_nugget(overriden_attributes = {})
+    default_attributes = {
+      content: "TIL about the difference betweeen .size and .count in Rails",
+      source: "https://example.com/messages/1",
+      author: create_author
+    }
+    GoldMiner::GoldNugget.new(**default_attributes.merge(overriden_attributes))
+  end
+
   def create_slack_user(overriden_attributes = {})
     default_attributes = {
       id: "U123",


### PR DESCRIPTION
This PR is another step in the [journey of decoupling](https://github.com/thoughtbot/gold_miner/pull/33) a few things in this app.

The main change here is that `SlackExplorer#explore` now returns `GoldNuggets`, instead of `Slack::Messages`. This helps to decouple the app from Slack.

`GoldNugget` s could come from different sources, like Tweets/Toots instead of Slack messages.

Other significant changes:

- `Slack::Client` now returns a well-defined objects (`Slack::Message` and `Slack::User`). I'm trying to [parse more](https://lexi-lambda.github.io/blog/2019/11/05/parse-don-t-validate/), so the code can assume more things as it runs.
- Separate `Slack::User` and `Author`. Again, an `Author` is a broader concept. It could have come from Twitter.
- More domain-specific language in general (gold miner, explorers, nuggets, etc).
