### PR TITLE
Introduce Gold Miner distributors

### DIFF
--- a/exe/gold_miner
+++ b/exe/gold_miner
@@ -19,7 +19,8 @@ GoldMiner
   .fmap { |gold_container|
     debug "Found #{gold_container.gold_nuggets.size} messages in #{Time.now - t0} seconds."
 
-    puts GoldMiner.smith_blog_post(gold_container)
+    blog_post = GoldMiner.smith_blog_post(gold_container)
+    GoldMiner.distribute(blog_post)
   }
   .or { |error| abort "[ERROR] #{error}" }
 

--- a/lib/gold_miner.rb
+++ b/lib/gold_miner.rb
@@ -20,6 +20,10 @@ module GoldMiner
     BlogPostSmith.new(...).smith(gold_container)
   end
 
+  def distribute(blog_post)
+    TerminalDistributor.new.distribute(blog_post)
+  end
+
   private
 
   def prepare(slack_client)

--- a/lib/gold_miner/terminal_distributor.rb
+++ b/lib/gold_miner/terminal_distributor.rb
@@ -1,0 +1,7 @@
+module GoldMiner
+  class TerminalDistributor
+    def distribute(blog_post)
+      puts blog_post
+    end
+  end
+end

--- a/spec/gold_miner/terminal_distributor_spec.rb
+++ b/spec/gold_miner/terminal_distributor_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe GoldMiner::TerminalDistributor do
+  it_behaves_like "distributor"
+
+  describe "#distribute" do
+    it "prints the blog post to STDOUT" do
+      blog_post = double("blog_post", to_s: "A blog post")
+
+      expect { subject.distribute(blog_post) }.to output("A blog post\n").to_stdout
+    end
+  end
+end

--- a/spec/support/behaves_like_distributor.rb
+++ b/spec/support/behaves_like_distributor.rb
@@ -1,0 +1,3 @@
+RSpec.shared_examples "distributor" do
+  it { is_expected.to respond_to(:distribute) }
+end


### PR DESCRIPTION
Distribution is the last step after mining and smithing gold. It's the final step, where we deliver something useful to the world. We do that using distributor objects.

Distributors are objects that respond to `#distribute` and perform some kind of "delivery". For now, we have the `TerminalDistributor` which prints the generated blog post to the terminal. I'm [planning to add] a GitHub distributor that will open a pull request for the generated blog post.

Unlike Smiths, that take GoldContainers with GoldNuggets, I haven't found a good abstraction for what Distributors accept. We only produce blog posts, so I'm using that for now. It's not generic, but I'll wait until we have more examples of distributors to find a good abstraction.

[planning to add]: https://github.com/thoughtbot/gold_miner/issues/1